### PR TITLE
Update for Zig 0.15

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
     .dependencies = .{
         .expat = .{
             .url = "https://github.com/libexpat/libexpat/releases/download/R_2_6_0/expat-2.6.0.tar.gz",
-            .hash = "12203b6e6ec7bb3b967233de8bd51524a16be5e9180dba53160c487394619cfb7626",
+            .hash = "N-V-__8AAGnTNQA7bm7HuzuWcjPei9UVJKFr5ekYDbpTFgxI",
         },
     },
 }


### PR DESCRIPTION
Use the new format for hashes, otherwise it re-downloads on every build in dependent projects.

Example:
`proj-a` depends on `expat.zig` which depends on `libexpat`,
everytime you call `zig build` on `proj-a`, `libexpat` gets fetched, eventually hitting github's rate-limiting.

Otherwise, the library is fully functional without this PR in Zig 0.15.2.